### PR TITLE
Copy correct files to release directory

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,9 +1,0 @@
-Andreas Brauchli <andreas.brauchli@sensirion.com>
-Christian Jaeggi <christian.jaeggi@sensirion.com>
-Pascal Sachs <pascal.sachs@sensirion.com>
-Daniel Lehmann <Daniel.Lehmann@sensirion.com>
-David Frey <david.frey@sensirion.com>
-Jerome Sieber <jsieber@sensirion.com>
-Salomon Diether <salomon.diether@sensirion.com>
-Silvan Fischer <silvan.fischer@sensirion.com>
-Sven Gruebel <Sven.Gruebel@sensirion.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,23 +5,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
- * [`fixed`]  Improved compatibility with C++ compilers
- * [`changed`]  Return types are now `int16_t` instead of `int8_t` (in line with
-                other embedded drivers).
- * [`changed`]  Functions are now dedicated per sensor (e.g. `sts3x_probe()`
-                instead of `sts_probe()`)
- * [`changed`]  Move the i2c init call out of `probe()` and into the example
- * [`changed`]  Rename `git_version.[ch]` to `sts_git_version.[ch]`
- * [`added`]  Add `sts3x_read_serial()` to read out the serial number
- * [`changed`]  Split out `default_config.inc` from Makefile to configure paths
-                and CFLAGS
- * [`changed`]  Only one example with either `hw_i2c` or `sw_i2c` is built,
-                depending on `CONFIG_I2C_TYPE`. Defaults to `hw_i2c`.
- * [`fixed`]  Measurement duration could take at most 15.5ms (datasheet) but we
-              only waited 15ms
- * [`added`]  Add `STS3X_MEASUREMENT_DURATION_USEC` to header
+ * [`fixed`]   Improved compatibility with C++ compilers
+ * [`changed`] Return types are now `int16_t` instead of `int8_t` (in line with
+               other embedded drivers).
+ * [`changed`] Functions are now dedicated per sensor (e.g. `sts3x_probe()`
+               instead of `sts_probe()`)
+ * [`changed`] Move the i2c init call out of `probe()` and into the example
+ * [`changed`] Rename `git_version.[ch]` to `sts_git_version.[ch]`
+ * [`added`]   Add `sts3x_read_serial()` to read out the serial number
+ * [`changed`] Split out `default_config.inc` from Makefile to configure paths
+               and CFLAGS
+ * [`changed`] Only one example with either `hw_i2c` or `sw_i2c` is built,
+               depending on `CONFIG_I2C_TYPE`. Defaults to `hw_i2c`.
+ * [`fixed`]   Measurement duration could take at most 15.5ms (datasheet) but we
+               only waited 15ms
+ * [`added`]   Add `STS3X_MEASUREMENT_DURATION_USEC` to header
  * [`changed`] Fix compilation warnings when compiling the linux user space
                sample implementation with `CONFIG_I2C_TYPE` set to `sw_i2c`
+ * [`removed`] Remove the `AUTHORS` file from the driver and the
+               `embedded-common` submodule, as it adds more noise than benefit.
+               The contributors can be found in the git log.
 
 ## [1.0.0] - 2019-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * [`removed`] Remove the `AUTHORS` file from the driver and the
                `embedded-common` submodule, as it adds more noise than benefit.
                The contributors can be found in the git log.
+ * [`fixed`]   Copy correct `CHANGELOG.md` and `LICENSE` files to target
+               locations when running the `release` target of the driver's root
+               Makefile.
 
 ## [1.0.0] - 2019-05-13
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ $(release_drivers): sts-common/sts_git_version.c
 	echo 'sts_driver_dir = .' >> $${pkgdir}/user_config.inc && \
 	echo 'sts_common_dir = .' >> $${pkgdir}/user_config.inc && \
 	echo 'sensirion_common_dir = .' >> $${pkgdir}/user_config.inc && \
-	echo 'sts3x_dir = .' >> $${pkgdir}/user_config.inc && \
+	echo "$${driver}_dir = ." >> $${pkgdir}/user_config.inc && \
 	cd "$${pkgdir}" && $(MAKE) $(MFLAGS) && $(MAKE) clean $(MFLAGS) && cd - && \
 	cd release && zip -r "$${pkgname}.zip" "$${pkgname}" && cd - && \
 	ln -sfn $${pkgname} $@

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ $(release_drivers): sts-common/sts_git_version.c
 	cp -r embedded-common/* "$${pkgdir}" && \
 	cp -r sts-common/* "$${pkgdir}" && \
 	cp -r $${driver}/* "$${pkgdir}" && \
+	cp CHANGELOG.md LICENSE "$${pkgdir}" && \
 	echo 'sts_driver_dir = .' >> $${pkgdir}/user_config.inc && \
 	echo 'sts_common_dir = .' >> $${pkgdir}/user_config.inc && \
 	echo 'sensirion_common_dir = .' >> $${pkgdir}/user_config.inc && \


### PR DESCRIPTION
The files `AUTHORS`, `CHANGELOG.md`, `LICENSE`, and `README.md` in the
release directories were copied from the `embedded-common` submodule
instead of the driver's root folder. Fix this issue by overwriting the
files with the correct files.

Check the following:

 - [x] Breaking changes marked in commit message
 - [x] Changelog updated
 - [x] Code style cleaned (ran `make style-fix`)
 - [ ] Tested on actual hardware
