### PR TITLE
Use newer cibuilds docker image in release CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,13 +55,13 @@ jobs:
 
   github-release:
     docker:
-      - image: cibuilds/github:0.10
+      - image: cibuilds/github:0.13
     steps:
       - attach_workspace:
           at: /releases
       - run:
           name: "Publish Release on GitHub"
-          command: ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -n "Embedded-STS ${CIRCLE_TAG}" -delete ${CIRCLE_TAG} /releases/
+          command: ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -n "Embedded-STS ${CIRCLE_TAG}" -soft ${CIRCLE_TAG} /releases/
 
 workflows:
   version: 2


### PR DESCRIPTION
Version 0.10 of `cibuilds/github` does not support the `-n` flag of
`ghr`. Update it to newest version 0.13

Check the following:

 - [ ] Breaking changes marked in commit message
 - [ ] Changelog updated
 - [ ] Code style cleaned (ran `make style-fix`)
 - [ ] Tested on actual hardware
