### PR TITLE
 Change makefile to only include needed files from embedded-common

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+ * [`changed`] Makefile to only include needed files from embedded-common
 
 ## [2.1.0] - 2020-06-26
  * [`changed`]  Use configuration independent endianness conversions. No more

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,12 @@ $(release_drivers): sts-common/sts_git_version.c
 	export pkgname="$${driver}-$${tag}" && \
 	export pkgdir="release/$${pkgname}" && \
 	rm -rf "$${pkgdir}" && mkdir -p "$${pkgdir}" && \
-	cp -r embedded-common/* "$${pkgdir}" && \
+	cp -r embedded-common/hw_i2c/ "$${pkgdir}" && \
+	cp -r embedded-common/sw_i2c/ "$${pkgdir}" && \
+	cp embedded-common/sensirion_arch_config.h "$${pkgdir}" && \
+	cp embedded-common/sensirion_common.c "$${pkgdir}" && \
+	cp embedded-common/sensirion_common.h "$${pkgdir}" && \
+	cp embedded-common/sensirion_i2c.h "$${pkgdir}" && \
 	cp -r sts-common/* "$${pkgdir}" && \
 	cp -r $${driver}/* "$${pkgdir}" && \
 	cp CHANGELOG.md LICENSE "$${pkgdir}" && \


### PR DESCRIPTION
Change makefile to only include the needed parts of embedded-common
in the release package.

Check the following:

 - [ ] Breaking changes marked in commit message
 - [ ] Changelog updated
 - [na] Code style cleaned (ran `make style-fix`)
 - [na] Tested on actual hardware
